### PR TITLE
Update EGrabber SDK Version

### DIFF
--- a/EuresysApp/src/ADEuresys.cpp
+++ b/EuresysApp/src/ADEuresys.cpp
@@ -137,7 +137,7 @@ ADEuresys::ADEuresys(const char *portName, const char* cameraId, int numEGBuffer
     epicsSnprintf(driverVersionString, sizeof(driverVersionString), "%d.%d.%d", 
                   DRIVER_VERSION, DRIVER_REVISION, DRIVER_MODIFICATION);
     setStringParam(NDDriverVersion,driverVersionString);
-    setStringParam(ADSDKVersion, Euresys::Internal::EGrabberClientVersion);
+    setStringParam(ADSDKVersion, Euresys::Internal::EGrabberApiVersion);
     resetErrorCounts();
     
     // shutdown on exit


### PR DESCRIPTION
In this pull request, I added the following features:

1. Updated the EGrabber SDK
Upgraded the EGrabber SDK version from egrabber-linux-x86_64-24.01.2.67 to egrabber-linux-x86_64-25.02.0.39.
This update required changing **_EgrabberClientVersion_** to **_EGrabberApiVersion_**.